### PR TITLE
feat: readiness probe for multiwoven-worker

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: multiwoven
 description: Open-source reverse ETL, an alternative to Hightouch, Census etc. 🔥
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.5.0
+appVersion: "0.5.0"
 maintainers:
   - name: subintp
   - name: RafaelOAiSquared

--- a/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: {{ include "chart.fullname" . }}-worker
   namespace: {{ .Values.kubernetesNamespace }}
-
   labels:
     app: {{ include "chart.fullname" . }}-worker
     io.kompose.service: {{ include "chart.fullname" . }}-worker
@@ -32,5 +31,13 @@ spec:
             name: {{ include "chart.fullname" . }}-config
         image: {{ .Values.multiwovenWorker.multiwovenWorker.image.repository }}:{{ .Values.multiwovenWorker.multiwovenWorker.image.tag | default .Chart.AppVersion }}
         name: {{ include "chart.fullname" . }}-worker
+        ports:
+        - containerPort: 4567
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 4567
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources: {{- toYaml .Values.multiwovenWorker.multiwovenWorker.resources | nindent 10 }}
       restartPolicy: Always


### PR DESCRIPTION
## Description

<!-- A brief description of what this pull request does. Include the purpose of the change and any relevant context. e.g
 This PR enhances the process of data fetching in the application -->

Added readiness probe to `multiwoven-worker` on `:4567/health`

## Related Issue
[INFRA-23](https://linear.app/ai-squared/issue/INFRA-23/add-liveliness-and-readiness-probe-for-multiwoven-server-and-worker)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New Connector (Destination or Source Connector)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## How Has This Been Tested?

Current deployment is not responding to health check probe. Will update when available.