### PR TITLE
feat: adding configuration for temporal cloud

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: multiwoven
 description: Open-source reverse ETL, an alternative to Hightouch, Census etc. 🔥
 type: application
-version: 0.9.0
-appVersion: "0.9.0"
+version: 0.10.0
+appVersion: "0.10.0"
 maintainers:
   - name: subintp
   - name: RafaelOAiSquared

--- a/charts/multiwoven/templates/multiwoven-server-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-server-deployment.yaml
@@ -45,4 +45,19 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources: {{- toYaml .Values.multiwovenServer.multiwovenServer.resources | nindent 10 }}
+{{ if not .Values.temporal.enabled }}
+        volumeMounts:
+        - name: ssl
+          mountPath: /certs
+          readOnly: false
+      volumes:
+      - name: ssl
+        secret:
+          secretName: temporal-cloud
+          items:
+          - key: temporal-client-key
+            path: ./temporal.pem
+          - key: temporal-root-cert
+            path: ./temporal.key
+{{ end }}
       restartPolicy: Always

--- a/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
@@ -48,4 +48,19 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources: {{- toYaml .Values.multiwovenWorker.multiwovenWorker.resources | nindent 10 }}
+{{ if not .Values.temporal.enabled }}
+        volumeMounts:
+        - name: ssl
+          mountPath: /certs
+          readOnly: false
+      volumes:
+      - name: ssl
+        secret:
+          secretName: temporal-cloud
+          items:
+          - key: temporal-client-key
+            path: ./temporal.pem
+          - key: temporal-root-cert
+            path: ./temporal.key
+{{ end }}
       restartPolicy: Always


### PR DESCRIPTION
## Description

<!-- A brief description of what this pull request does. Include the purpose of the change and any relevant context. e.g
 This PR enhances the process of data fetching in the application -->

Configuration for using Temporal Cloud instead of cluster Temporal deployment. It requires the creation of cluster `secret` named `temporal-cloud` with two keys: `temporal-client-key` with the client.pem and `temporal-root-cert` with the client.key.

## Related Issue
[INFRA-24](https://linear.app/ai-squared/issue/INFRA-24/use-temporal-cloud-in-the-helm-chart)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New Connector (Destination or Source Connector)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## How Has This Been Tested?

1. Deploy with:
```shell
helm upgrade -i -n multiwoven \
  --set temporal.enabled=false \
  --set multiwovenConfig.temporalHost=<temporal-host> \
  --set multiwovenConfig.temporalNamespace=<temporal-namespace> \
  --set multiwovenWorker.multiwovenWorker.args={./app/temporal/cli/worker}
```
2. Run `kubectl get pods -n multiwoven` and confirm that:
* `multiwoven-temporal` is not deployed
* `multiwoven-temporal-ui` is not deployed
* `multiwoven-worker` is running
* `multiwoven-server` is running