### PR TITLE
Fix/ingress update

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: multiwoven
 description: Open-source reverse ETL, an alternative to Hightouch, Census etc. 🔥
 type: application
-version: 0.17.0
-appVersion: "0.17.0"
+version: 0.18.0
+appVersion: "0.18.0"
 maintainers:
   - name: subintp
   - name: RafaelOAiSquared

--- a/charts/multiwoven/templates/acme-challenge-deployment.yaml
+++ b/charts/multiwoven/templates/acme-challenge-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}-acme-challenge
+  namespace: {{ .Values.kubernetesNamespace }}
+spec:
+  replicas: {{ .Values.acmeChallenge.acmeChallenge.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "chart.fullname" . }}-acme-challenge
+  template:
+    metadata:
+      labels:
+        app: {{ include "chart.fullname" . }}-acme-challenge
+    spec:
+      containers:
+        - name: {{ include "chart.fullname" . }}-acme-challenge
+          image: {{ .Values.acmeChallenge.acmeChallenge.image.repository }}:{{ .Values.acmeChallenge.acmeChallenge.image.tag | default .Chart.AppVersion }}
+          ports:
+            - containerPort: {{ (index .Values.acmeChallenge.ports 0).port }}
+          volumeMounts:
+            - name: acme-challenge
+              mountPath: /usr/share/nginx/html/.well-known/acme-challenge
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ (index .Values.acmeChallenge.ports 0).port }}
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ (index .Values.acmeChallenge.ports 0).port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources: {{- toYaml .Values.acmeChallenge.acmeChallenge.resources | nindent 10 }}
+      volumes:
+        - name: acme-challenge
+          emptyDir: {}

--- a/charts/multiwoven/templates/acme-challenge-service.yaml
+++ b/charts/multiwoven/templates/acme-challenge-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}-acme-challenge-service
+  namespace: {{ .Values.kubernetesNamespace }}
+spec:
+  selector:
+    app: {{ include "chart.fullname" . }}-acme-challenge
+  ports:
+    - protocol: TCP
+      port: {{ (index .Values.acmeChallenge.ports 0).port }}
+      targetPort: {{ (index .Values.acmeChallenge.ports 0).port }}

--- a/charts/multiwoven/templates/multiwoven-ingress.yaml
+++ b/charts/multiwoven/templates/multiwoven-ingress.yaml
@@ -11,6 +11,8 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     cert-manager.io/issuer: {{ .Values.multiwovenConfig.tlsCertIssuer }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
 spec:
   ingressClassName: nginx
   tls:
@@ -25,23 +27,37 @@ spec:
   - host:  {{ .Values.multiwovenConfig.uiHost }}
     http:
       paths:
-      - backend:
+      - path: /.well-known/acme-challenge/
+        pathType: Prefix
+        backend:
+          service:
+            name: acme-challenge-service
+            port:
+              number: {{ (index .Values.acmeChallenge.ports 0).port }}
+      - path: /(.*)
+        pathType: Prefix
+        backend:
           service:
             name: '{{ include "chart.fullname" . }}-ui'
             port:
-              number: 8000
-        path: /(.*)
-        pathType: Prefix
+              number: {{ (index .Values.multiwovenUI.ports 0).port }}
   - host: {{ .Values.multiwovenConfig.apiHost }}
     http:
       paths:
-      - backend:
+      - path: /.well-known/acme-challenge/
+        pathType: Prefix
+        backend:
+          service:
+            name: acme-challenge-service
+            port:
+              number: {{ (index .Values.acmeChallenge.ports 0).port }}
+      - path: /(.*)
+        pathType: Prefix
+        backend:
           service:
             name: '{{ include "chart.fullname" . }}-server'
             port:
-              number: 3000
-        path: /(.*)
-        pathType: Prefix
+              number: {{ (index .Values.multiwovenServer.ports 0).port }}
 {{ if .Values.temporal.enabled }}
   - host: {{ .Values.multiwovenConfig.temporalUiHost }}
     http:
@@ -50,7 +66,7 @@ spec:
           service:
             name: '{{ include "chart.fullname" . }}-temporal-ui'
             port:
-              number: 8080
+              number: {{ (index .Values.temporalUi.ports 0).port }}
         path: /(.*)
         pathType: Prefix
 {{ end }}

--- a/charts/multiwoven/templates/multiwoven-server-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-server-deployment.yaml
@@ -32,16 +32,16 @@ spec:
         livenessProbe:
           httpGet:
             path: /
-            port: 3000
+            port: {{ (index .Values.multiwovenServer.ports 0).port }}
           initialDelaySeconds: 15
           periodSeconds: 10
         name: {{ include "chart.fullname" . }}-server
         ports:
-        - containerPort: 3000
+        - containerPort: {{ (index .Values.multiwovenServer.ports 0).port }}
         readinessProbe:
           httpGet:
             path: /
-            port: 3000
+            port: {{ (index .Values.multiwovenServer.ports 0).port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources: {{- toYaml .Values.multiwovenServer.multiwovenServer.resources | nindent 10 }}

--- a/charts/multiwoven/templates/multiwoven-ui-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-ui-deployment.yaml
@@ -30,16 +30,16 @@ spec:
         livenessProbe:
           httpGet:
             path: /
-            port: 8000
+            port: {{ (index .Values.multiwovenUI.ports 0).port }}
           initialDelaySeconds: 15
           periodSeconds: 10
         name: {{ include "chart.fullname" . }}-ui
         ports:
-        - containerPort: 8000
+        - containerPort: {{ (index .Values.multiwovenUI.ports 0).port }}
         readinessProbe:
           httpGet:
             path: /
-            port: 8000
+            port: {{ (index .Values.multiwovenUI.ports 0).port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources: {{- toYaml .Values.multiwovenUI.multiwovenUI.resources | nindent 10 }}

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -167,3 +167,20 @@ temporalUi:
       repository: temporalio/ui
       tag: 2.22.3
   type: ClusterIP
+acmeChallenge:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+  replicas: 1
+  acmeChallenge:
+    image:
+      repository: nginx
+      tag: alpine
+    resources:
+      limits:
+        cpu: "64Mi"
+        memory: "250m"
+      requests:
+        cpu: "128Mi"
+        memory: "500m"


### PR DESCRIPTION
- parameterized port values
- added a deployment and service to handle acme-challenges from cert-manager so it can auto-rotate certificates before they expire. Previously, the challenges for api.squared.ai were being pushed to the application pod instead of being handled by the ingress. This new resource set handles all acme-challenges and guarantees that repeated acme-challenge requests don't chip away at the resources reserved for the application pods.