### PR TITLE
fix: add chart name to acme challenge service name in ingress template

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: multiwoven
 description: Open-source reverse ETL, an alternative to Hightouch, Census etc. 🔥
 type: application
-version: 0.19.0
-appVersion: "0.19.0"
+version: 0.20.0
+appVersion: "0.20.0"
 maintainers:
   - name: subintp
   - name: RafaelOAiSquared

--- a/charts/multiwoven/templates/multiwoven-ingress.yaml
+++ b/charts/multiwoven/templates/multiwoven-ingress.yaml
@@ -31,7 +31,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: acme-challenge-service
+            name: '{{ include "chart.fullname" . }}-acme-challenge-service'
             port:
               number: {{ (index .Values.acmeChallenge.ports 0).port }}
       - path: /(.*)
@@ -48,7 +48,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: acme-challenge-service
+            name: '{{ include "chart.fullname" . }}-acme-challenge-service'
             port:
               number: {{ (index .Values.acmeChallenge.ports 0).port }}
       - path: /(.*)


### PR DESCRIPTION
Added full chart name to acme challenge service name in the ingress file. The ingress file as-is is unable to find the multiwoven-acme-challenge-service. 