### PR TITLE
Feature  conditionally restrict traffic to staging env to nordlayer servers

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: multiwoven
 description: Open-source reverse ETL, an alternative to Hightouch, Census etc. 🔥
 type: application
-version: 0.24.0
-appVersion: "0.24.0"
+version: 0.25.0
+appVersion: "0.25.0"
 maintainers:
   - name: subintp
   - name: RafaelOAiSquared

--- a/charts/multiwoven/templates/multiwoven-ingress.yaml
+++ b/charts/multiwoven/templates/multiwoven-ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     cert-manager.io/issuer: {{ .Values.multiwovenConfig.tlsCertIssuer }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.multiwovenConfig.allowedSourceIP }}
 spec:
   ingressClassName: nginx
   tls:

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -2,6 +2,7 @@ kubernetesClusterDomain: cluster.local
 kubernetesNamespace: multiwoven
 multiwovenConfig:
   allowedHost: ""
+  allowedSourceIP: "0.0.0.0/0"
   apiHost: api.multiwoven.com
   appRevision: unknown
   appEnv: community


### PR DESCRIPTION
## Added the **allowedSourceIP** value
This variable determines the specific external IP address(es) and/or IP address ranges that are allowed to access the app. The default value is 0.0.0.0/0 meaning any IP address is allowed to access the app. If you want to add multiple, they can be added as a comma-delimited list.

**Important Note:** if you are adding this comma-delimited list using helm's --set flag, you will need to (1) double-quote the entire value and (2) escape the commas (\,) like this "1.1.1.1\,2.2.2.2". If you don't, helm will interpret the comma as the beginning of a new key with no value and throw an error.

## Added the "nginx.ingress.kubernetes.io/whitelist-source-range:" annotation to the ingress template
This is the annotation that actually uses the allowedSourceIP value and performs the work of restricting traffic on the ingress.
