### PR TITLE
fix: learned today that the warning about the useless regex in the pa…

### DIFF
--- a/charts/multiwoven/templates/multiwoven-ingress.yaml
+++ b/charts/multiwoven/templates/multiwoven-ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
   {{- include "chart.labels" . | nindent 4 }}
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     cert-manager.io/issuer: {{ .Values.multiwovenConfig.tlsCertIssuer }}
@@ -29,7 +28,7 @@ spec:
   - host:  {{ .Values.multiwovenConfig.uiHost }}
     http:
       paths:
-      - path: /(.*)
+      - path: /
         pathType: Prefix
         backend:
           service:
@@ -39,7 +38,7 @@ spec:
   - host: {{ .Values.multiwovenConfig.apiHost }}
     http:
       paths:
-      - path: /(.*)
+      - path: /
         pathType: Prefix
         backend:
           service:
@@ -49,7 +48,7 @@ spec:
   - host: {{ .Values.multiwovenConfig.workerHost }}
     http:
       paths:
-      - path: /(.*)
+      - path: /
         pathType: Prefix
         backend:
           service:
@@ -65,6 +64,6 @@ spec:
             name: '{{ include "chart.fullname" . }}-temporal-ui'
             port:
               number: {{ (index .Values.temporalUi.ports 0).port }}
-        path: /(.*)
+        path: /
         pathType: Prefix
 {{ end }}


### PR DESCRIPTION
[…th -> (.*), causes the ingress to be rejected in later versions of K8s. Finally removed.](fix: learned today that the warning about the useless regex in the path -> (.*), causes the ingress to be rejected in later versions of K8s. Finally removed.)