### PR TITLE
Fix  allow the use of secret names with capital letters

### DIFF
--- a/charts/multiwoven/templates/multiwoven-cluster-role.yaml
+++ b/charts/multiwoven/templates/multiwoven-cluster-role.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create", "update", "watch"]
+    verbs: ["get", "create", "update", "watch", "list", "patch"]
 
 ---
 

--- a/charts/multiwoven/templates/multiwoven-secret-provider-class.yaml
+++ b/charts/multiwoven/templates/multiwoven-secret-provider-class.yaml
@@ -12,15 +12,15 @@ spec:
     provider: aws
     parameters:
         objects: |
-            - objectName: {{ .Values.secretsStore.aws.dbCredsSecretName }}
-              objectType: secretsmanager
-              jmesPath:
-                - path: u
-                  objectAlias: DB_USERNAME
-                - path: p
-                  objectAlias: DB_PASSWORD
+          - objectName: {{ .Values.secretsStore.aws.dbCredsSecretName }}
+            objectType: secretsmanager
+            jmesPath:
+              - path: u
+                objectAlias: DB_USERNAME
+              - path: p
+                objectAlias: DB_PASSWORD
     secretObjects:
-    - secretName: {{ .Values.secretsStore.aws.dbCredsSecretName }}
+    - secretName: dbcredsfile
       type: Opaque
       data:
         - objectName: DB_PASSWORD

--- a/charts/multiwoven/templates/multiwoven-secret-provider-class.yaml
+++ b/charts/multiwoven/templates/multiwoven-secret-provider-class.yaml
@@ -20,7 +20,7 @@ spec:
               - path: p
                 objectAlias: DB_PASSWORD
     secretObjects:
-    - secretName: dbcredsfile
+    - secretName: {{ .Values.secretsStore.secretAlias }}
       type: Opaque
       data:
         - objectName: DB_PASSWORD

--- a/charts/multiwoven/templates/multiwoven-server-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-server-deployment.yaml
@@ -30,12 +30,12 @@ spec:
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.secretsStore.aws.dbCredsSecretName }}
+              name: dbcredsfile
               key: DB_PASSWORD
         - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.secretsStore.aws.dbCredsSecretName }}
+              name: dbcredsfile
               key: DB_USERNAME
         {{ end }}
         - name: KUBERNETES_CLUSTER_DOMAIN

--- a/charts/multiwoven/templates/multiwoven-server-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-server-deployment.yaml
@@ -30,12 +30,12 @@ spec:
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: dbcredsfile
+              name: {{ .Values.secretsStore.secretAlias }}
               key: DB_PASSWORD
         - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: dbcredsfile
+              name: {{ .Values.secretsStore.secretAlias }}
               key: DB_USERNAME
         {{ end }}
         - name: KUBERNETES_CLUSTER_DOMAIN

--- a/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
@@ -35,12 +35,12 @@ spec:
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: dbcredsfile
+              name: {{ .Values.secretsStore.secretAlias }}
               key: DB_PASSWORD
         - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: dbcredsfile
+              name: {{ .Values.secretsStore.secretAlias }}
               key: DB_USERNAME
         {{ end }}
         envFrom:

--- a/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
@@ -35,12 +35,12 @@ spec:
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.secretsStore.aws.dbCredsSecretName }}
+              name: dbcredsfile
               key: DB_PASSWORD
         - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.secretsStore.aws.dbCredsSecretName }}
+              name: dbcredsfile
               key: DB_USERNAME
         {{ end }}
         envFrom:

--- a/charts/multiwoven/templates/temporal-deployment.yaml
+++ b/charts/multiwoven/templates/temporal-deployment.yaml
@@ -41,7 +41,7 @@ spec:
             {{ end }}
             {{ if .Values.secretsStore.enabled}}
             secretKeyRef:
-              name: dbcredsfile
+              name: {{ .Values.secretsStore.secretAlias }}
               key: DB_PASSWORD
             {{ end }}
         - name: POSTGRES_SEEDS
@@ -58,7 +58,7 @@ spec:
             {{ end }}
             {{ if .Values.secretsStore.enabled}}
             secretKeyRef:
-              name: dbcredsfile
+              name: {{ .Values.secretsStore.secretAlias }}
               key: DB_USERNAME
             {{ end }}
         {{ if .Values.multiwovenConfig.temporalPostgresSsl }}

--- a/charts/multiwoven/templates/temporal-deployment.yaml
+++ b/charts/multiwoven/templates/temporal-deployment.yaml
@@ -41,7 +41,7 @@ spec:
             {{ end }}
             {{ if .Values.secretsStore.enabled}}
             secretKeyRef:
-              name: {{ .Values.secretsStore.aws.dbCredsSecretName }}
+              name: dbcredsfile
               key: DB_PASSWORD
             {{ end }}
         - name: POSTGRES_SEEDS
@@ -58,7 +58,7 @@ spec:
             {{ end }}
             {{ if .Values.secretsStore.enabled}}
             secretKeyRef:
-              name: {{ .Values.secretsStore.aws.dbCredsSecretName }}
+              name: dbcredsfile
               key: DB_USERNAME
             {{ end }}
         {{ if .Values.multiwovenConfig.temporalPostgresSsl }}

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -84,6 +84,7 @@ serviceAccount:
 
 secretsStore:
   enabled: false
+  secretAlias: dbsecret-f01dd256e712
   aws:
     dbCredsSecretName: ""
 


### PR DESCRIPTION
Vanguard Secrets Manager secret names have capital letters which are illegal in the ref field of K8s environment variables. The changes made are to allow the use of secrets with names containing capital letters by aliasing them first with lowercase aliases.