### PR TITLE
Feature  conditional disabling service account token automount

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: multiwoven
 description: Open-source reverse ETL, an alternative to Hightouch, Census etc. 🔥
 type: application
-version: 0.36.0
-appVersion: "0.36.0"
+version: 0.38.0
+appVersion: "0.38.0"
 maintainers:
   - name: subintp
   - name: RafaelOAiSquared

--- a/charts/multiwoven/templates/multiwoven-server-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-server-deployment.yaml
@@ -24,6 +24,7 @@ spec:
       {{ if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{ end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken.enabled }}
       containers:
       - env:
         {{ if .Values.secretsStore.enabled }}

--- a/charts/multiwoven/templates/multiwoven-ui-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-ui-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         io.kompose.service: {{ include "chart.fullname" . }}-ui
       {{- include "chart.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken.enabled }}
       containers:
       - env:
         envFrom:

--- a/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
@@ -24,6 +24,7 @@ spec:
       {{ if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{ end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken.enabled }}
       containers:
       - args: {{- toYaml .Values.multiwovenWorker.multiwovenWorker.args | nindent 8 }}
         env:

--- a/charts/multiwoven/templates/temporal-deployment.yaml
+++ b/charts/multiwoven/templates/temporal-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       {{ if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{ end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken.enabled }}
       containers:
       - env:
         - name: DB

--- a/charts/multiwoven/templates/temporal-ui-deployment.yaml
+++ b/charts/multiwoven/templates/temporal-ui-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         kompose.cmd: kompose convert
         kompose.version: 1.32.0 (HEAD)
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken.enabled }}
       containers:
       - env:
         - name: TEMPORAL_ADDRESS

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -66,7 +66,7 @@ multiwovenConfig:
   workerHost: worker.multiwoven.com
 
 automountServiceAccountToken:
-  enabled: true # k8s default is true
+  enabled: true
 
 externalDNS:
   enabled: false

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -64,6 +64,9 @@ multiwovenConfig:
   viteFavIconUrl: ""
   workerHost: worker.multiwoven.com
 
+automountServiceAccountToken:
+  enabled: true # k8s default is true
+
 externalDNS:
   enabled: false
 


### PR DESCRIPTION
Add ability to toggle on/off the automounting of a service account token.

Context: In VG, it is required that this behavior is disabled, however, it is enabled by default and allows the application(s) running in a K8s pod the ability to make calls to the K8s API (prob most commonly for fetching the data stored in secrets on the fly in lieu of that information being mounted into the pod during startup). The change does not exist within the if/end statement for the custom service account name because if a custom service account is not specified, the pod automounts the token for the namespace's default service account so a service account is always in-use.