### PR TITLE
Feature  add conditional security context section

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: multiwoven
 description: Open-source reverse ETL, an alternative to Hightouch, Census etc. 🔥
 type: application
-version: 0.37.0
-appVersion: "0.37.0"
+version: 0.39.0
+appVersion: "0.39.0"
 maintainers:
   - name: subintp
   - name: RafaelOAiSquared

--- a/charts/multiwoven/templates/multiwoven-server-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-server-deployment.yaml
@@ -44,6 +44,20 @@ spec:
         - configMapRef:
             name: {{ include "chart.fullname" . }}-config
         image: {{ .Values.multiwovenServer.multiwovenServer.image.repository }}:{{ .Values.multiwovenServer.multiwovenServer.image.tag | default .Chart.AppVersion }}
+        {{ if .Values.securityContext.enabled }}
+        securityContext:
+          {{ if .Values.securityContext.capabilities.enabled }}
+          capabilities:
+            {{ if .Values.securityContext.capabilities.drop.enabled }}
+            drop:
+            {{- if .Values.securityContext.capabilities.drop.permissions }}
+            {{- range .Values.securityContext.capabilities.drop.permissions }}
+              - {{ . }}
+            {{- end }}
+            {{- end }}
+          {{ end }}
+          {{ end }}
+        {{ end }}
         livenessProbe:
           httpGet:
             path: /

--- a/charts/multiwoven/templates/multiwoven-ui-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-ui-deployment.yaml
@@ -27,6 +27,20 @@ spec:
         - configMapRef:
             name: {{ include "chart.fullname" . }}-config
         image: {{ .Values.multiwovenUI.multiwovenUI.image.repository }}:{{ .Values.multiwovenUI.multiwovenUI.image.tag | default .Chart.AppVersion }}
+        {{ if .Values.securityContext.enabled }}
+        securityContext:
+          {{ if .Values.securityContext.capabilities.enabled }}
+          capabilities:
+            {{ if .Values.securityContext.capabilities.drop.enabled }}
+            drop:
+            {{- if .Values.securityContext.capabilities.drop.permissions }}
+            {{- range .Values.securityContext.capabilities.drop.permissions }}
+              - {{ . }}
+            {{- end }}
+            {{- end }}
+          {{ end }}
+          {{ end }}
+        {{ end }}
         livenessProbe:
           httpGet:
             path: /

--- a/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
@@ -47,6 +47,20 @@ spec:
         - configMapRef:
             name: {{ include "chart.fullname" . }}-config
         image: {{ .Values.multiwovenWorker.multiwovenWorker.image.repository }}:{{ .Values.multiwovenWorker.multiwovenWorker.image.tag | default .Chart.AppVersion }}
+        {{ if .Values.securityContext.enabled }}
+        securityContext:
+          {{ if .Values.securityContext.capabilities.enabled }}
+          capabilities:
+            {{ if .Values.securityContext.capabilities.drop.enabled }}
+            drop:
+            {{- if .Values.securityContext.capabilities.drop.permissions }}
+            {{- range .Values.securityContext.capabilities.drop.permissions }}
+              - {{ . }}
+            {{- end }}
+            {{- end }}
+          {{ end }}
+          {{ end }}
+        {{ end }}
         livenessProbe:
           httpGet:
             path: /health

--- a/charts/multiwoven/templates/temporal-deployment.yaml
+++ b/charts/multiwoven/templates/temporal-deployment.yaml
@@ -76,6 +76,20 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.temporal.temporal.image.repository }}:{{ .Values.temporal.temporal.image.tag | default .Chart.AppVersion }}
+        {{ if .Values.securityContext.enabled }}
+        securityContext:
+          {{ if .Values.securityContext.capabilities.enabled }}
+          capabilities:
+            {{ if .Values.securityContext.capabilities.drop.enabled }}
+            drop:
+            {{- if .Values.securityContext.capabilities.drop.permissions }}
+            {{- range .Values.securityContext.capabilities.drop.permissions }}
+              - {{ . }}
+            {{- end }}
+            {{- end }}
+          {{ end }}
+          {{ end }}
+        {{ end }}
         name: temporal
         ports:
         - containerPort: 7233

--- a/charts/multiwoven/templates/temporal-ui-deployment.yaml
+++ b/charts/multiwoven/templates/temporal-ui-deployment.yaml
@@ -38,6 +38,20 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.temporalUi.temporalUi.image.repository }}:{{ .Values.temporalUi.temporalUi.image.tag | default .Chart.AppVersion }}
+        {{ if .Values.securityContext.enabled }}
+        securityContext:
+          {{ if .Values.securityContext.capabilities.enabled }}
+          capabilities:
+            {{ if .Values.securityContext.capabilities.drop.enabled }}
+            drop:
+            {{- if .Values.securityContext.capabilities.drop.permissions }}
+            {{- range .Values.securityContext.capabilities.drop.permissions }}
+              - {{ . }}
+            {{- end }}
+            {{- end }}
+          {{ end }}
+          {{ end }}
+        {{ end }}
         name: temporal-ui
         ports:
         - containerPort: 8080

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -89,6 +89,15 @@ secretsStore:
   aws:
     dbCredsSecretName: ""
 
+securityContext:
+  enabled: false
+  capabilities:
+    enabled: false
+    drop:
+      enabled: false
+      permissions:
+        - "ALL"
+
 hpa:
   enabled: true
   multiwovenUI:


### PR DESCRIPTION
For VG: added security context section and the security context keys to trigger the dropping of all root-level permissions within the pod (ie. the application running in the pod cannot perform root user actions).

Tested in EKS and Staging (Azure) with values set to true. Created and deleted source and destination connectors. Verified security context configuration using the script here: https://aisquared.atlassian.net/wiki/spaces/ID/pages/413466635/Checking+the+security+context+of+all+K8s+pods

We should consider enabling this change in-house as it's a recommended security "best practice". If one of the pods is compromised, this severely limits what a bad actor can do within the container/pod.

New variables have been added to Staging, Production, QA and Community.