### PR TITLE
feat: adding support for azure spot instances

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: multiwoven
 description: Open-source reverse ETL, an alternative to Hightouch, Census etc. 🔥
 type: application
-version: 0.46.0
-appVersion: "0.46.0"
+version: 0.47.0
+appVersion: "0.47.0"
 maintainers:
   - name: subintp
   - name: RafaelOAiSquared

--- a/charts/multiwoven/templates/cluster-autoscaler-priority-expander.yaml
+++ b/charts/multiwoven/templates/cluster-autoscaler-priority-expander.yaml
@@ -1,0 +1,13 @@
+{{ if .Values.multiwovenConfig.azureSpot }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-autoscaler-priority-expander
+  namespace: kube-system
+data:
+  priorities: |-
+    100:
+      - .*spot*
+    10 :
+      - .*
+{{ end }}

--- a/charts/multiwoven/templates/multiwoven-server-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-server-deployment.yaml
@@ -54,6 +54,22 @@ spec:
               {{- end }}
               {{- end }}
       {{ end }}
+      {{ if .Values.multiwovenConfig.azureSpot }}
+        tolerations:
+        - key: "kubernetes.azure.com/scalesetpriority"
+          operator: "Equal"
+          value: "spot"
+          effect: "NoSchedule"
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpression:
+                - key: "kubernetes.azure.com/scalesetpriority"
+                  operator: In
+                  values:
+                  - "spot":
+      {{ end }}
       containers:
       - env:
         {{ if .Values.secretsStore.enabled }}

--- a/charts/multiwoven/templates/multiwoven-solid-worker-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-solid-worker-deployment.yaml
@@ -54,6 +54,22 @@ spec:
             {{- end }}
             {{- end }}
       {{ end }}
+      {{ if .Values.multiwovenConfig.azureSpot }}
+        tolerations:
+        - key: "kubernetes.azure.com/scalesetpriority"
+          operator: "Equal"
+          value: "spot"
+          effect: "NoSchedule"
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpression:
+                - key: "kubernetes.azure.com/scalesetpriority"
+                  operator: In
+                  values:
+                  - "spot":
+      {{ end }}
       containers:
       - args: {{- toYaml .Values.multiwovenSolidWorker.multiwovenSolidWorker.args | nindent 8 }}
         env:

--- a/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
@@ -54,6 +54,22 @@ spec:
             {{- end }}
             {{- end }}
       {{ end }}
+      {{ if .Values.multiwovenConfig.azureSpot }}
+        tolerations:
+        - key: "kubernetes.azure.com/scalesetpriority"
+          operator: "Equal"
+          value: "spot"
+          effect: "NoSchedule"
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpression:
+                - key: "kubernetes.azure.com/scalesetpriority"
+                  operator: In
+                  values:
+                  - "spot":
+      {{ end }}
       containers:
       - args: {{- toYaml .Values.multiwovenWorker.multiwovenWorker.args | nindent 8 }}
         env:

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -9,6 +9,7 @@ multiwovenConfig:
   appsignalPushApiKey: yourkey
   awsAccessKeyId: ""
   awsSecretAccessKey: ""
+  azureSpot: false
   databricksDriverPath: /opt/simba/spark/lib/64/libsparkodbc_sb64.so
   dbHost: multiwoven-postgresql
   dbPassword: password


### PR DESCRIPTION
Adds the flag `azureSpot` in `multiwovenConfig` to apply the toleration and affinity to schedule workloads on a Spot node pool.