### PR TITLE
fix: removed trailing character in affinity exp

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: multiwoven
 description: Open-source reverse ETL, an alternative to Hightouch, Census etc. 🔥
 type: application
-version: 0.48.0
-appVersion: "0.48.0"
+version: 0.49.0
+appVersion: "0.49.0"
 maintainers:
   - name: subintp
   - name: RafaelOAiSquared

--- a/charts/multiwoven/templates/multiwoven-server-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-server-deployment.yaml
@@ -68,7 +68,7 @@ spec:
               - key: "kubernetes.azure.com/scalesetpriority"
                 operator: In
                 values:
-                - "spot":
+                - "spot"
       {{ end }}
       containers:
       - env:

--- a/charts/multiwoven/templates/multiwoven-solid-worker-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-solid-worker-deployment.yaml
@@ -68,7 +68,7 @@ spec:
               - key: "kubernetes.azure.com/scalesetpriority"
                 operator: In
                 values:
-                - "spot":
+                - "spot"
       {{ end }}
       containers:
       - args: {{- toYaml .Values.multiwovenSolidWorker.multiwovenSolidWorker.args | nindent 8 }}

--- a/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
+++ b/charts/multiwoven/templates/multiwoven-worker-deployment.yaml
@@ -68,7 +68,7 @@ spec:
               - key: "kubernetes.azure.com/scalesetpriority"
                 operator: In
                 values:
-                - "spot":
+                - "spot"
       {{ end }}
       containers:
       - args: {{- toYaml .Values.multiwovenWorker.multiwovenWorker.args | nindent 8 }}


### PR DESCRIPTION
Removed trailing character in affinity exp.

```yaml
- key: "kubernetes.azure.com/scalesetpriority"
  operator: In
  values:
  - "spot":  # <-- this 
```