### PR TITLE
feature: allow the removal of dbPassword and temporalPostgresPassword…

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -4,8 +4,8 @@ description: |
   Multiwoven is an open-source reverse ETL tool, offering an alternative to qHightouch, Census, and similar platforms. 🔥
 # kubeVersion: ">=1.16.0"
 type: application
-version: 0.60.0
-appVersion: "0.60.0"
+version: 0.61.0
+appVersion: "0.61.0"
 home: https://github.com/Multiwoven/multiwoven
 sources:
   - https://docs.squared.ai/open-source/guides/setup/helm

--- a/charts/multiwoven/templates/multiwoven-config.yaml
+++ b/charts/multiwoven/templates/multiwoven-config.yaml
@@ -34,12 +34,14 @@ data:
   RAILS_LOG_LEVEL: {{ .Values.multiwovenConfig.railsLogLevel | quote }}
   SECRET_KEY_BASE: {{ .Values.multiwovenConfig.secretKeyBase | quote }}
   SKIP_DB_MIGRATION: {{ .Values.multiwovenConfig.skipDbMigration | quote }}
+  {{ if not .Values.multiwovenConfig.userEmailVerification}}
   SMTP_ADDRESS: {{ .Values.multiwovenConfig.smtpAddress | quote }}
   SMTP_HOST: {{ .Values.multiwovenConfig.smtpHost | quote }}
   SMTP_PASSWORD: {{ .Values.multiwovenConfig.smtpPassword | quote }}
   SMTP_PORT: {{ .Values.multiwovenConfig.smtpPort | quote }}
   SMTP_USERNAME: {{ .Values.multiwovenConfig.smtpUsername | quote }}
   SMTP_SENDER_EMAIL: {{ .Values.multiwovenConfig.smtpSenderEmail | quote }}
+  {{ end }}
   SNOWFLAKE_DRIVER_PATH: {{ .Values.multiwovenConfig.snowflakeDriverPath | quote }}
   STORAGE_ACCESS_KEY: {{ .Values.multiwovenConfig.storageAccessKey }}
   STORAGE_ACCOUNT_NAME: {{ .Values.multiwovenConfig.storageAccountName }}

--- a/charts/multiwoven/templates/multiwoven-config.yaml
+++ b/charts/multiwoven/templates/multiwoven-config.yaml
@@ -54,7 +54,9 @@ data:
   TEMPORAL_NAMESPACE: {{ .Values.multiwovenConfig.temporalNamespace | quote }}
   TEMPORAL_PORT: {{ .Values.multiwovenConfig.temporalPort | quote }}
   TEMPORAL_POSTGRES_DEFAULT_PORT: {{ .Values.multiwovenConfig.temporalPostgresDefaultPort | quote }}
+  {{ if not .Values.secretsStore.enabled }}
   TEMPORAL_POSTGRES_PASSWORD: {{ .Values.multiwovenConfig.temporalPostgresPassword | quote }}
+  {{ end }}
   TEMPORAL_POSTGRES_USER: {{ .Values.multiwovenConfig.temporalPostgresUser | quote }}
   TEMPORAL_POSTGRESQL_VERSION: {{ .Values.multiwovenConfig.temporalPostgresqlVersion | quote }}
   TEMPORAL_ROOT_CERT: {{ .Values.multiwovenConfig.temporalRootCert | quote }}

--- a/charts/multiwoven/templates/temporal-config-map.yaml
+++ b/charts/multiwoven/templates/temporal-config-map.yaml
@@ -19,7 +19,7 @@ data:
       datastores:
         default:
           sql:
-            pluginName: "postgres"
+            pluginName: {{ `{{ .Env.TEMPORAL_DB_PLUGIN }}` }}
             databaseName: {{ `{{ .Env.TEMPORAL_DEFAULT_DB_NAME }}` }}
             connectAddr: {{ `{{ .Env.TEMPORAL_DEFAULT_CONNECT_ADDR }}` }}
             connectProtocol: "tcp"
@@ -37,7 +37,7 @@ data:
               serverName: ""
         visibility:
           sql:
-            pluginName: "postgres"
+            pluginName: {{ `{{ .Env.TEMPORAL_DB_PLUGIN }}` }}
             databaseName: {{ `{{ .Env.TEMPORAL_VISIBILITY_DB_NAME }}` }}
             connectAddr: {{ `{{ .Env.TEMPORAL_VISIBILITY_CONNECT_ADDR }}` }}
             connectProtocol: "tcp"

--- a/charts/multiwoven/templates/temporal-deployment.yaml
+++ b/charts/multiwoven/templates/temporal-deployment.yaml
@@ -69,6 +69,8 @@ spec:
           value: "true"
         - name: POSTGRES_TLS_ENABLED
           value: "true"
+        - name: DB
+          value: {{ quote .Values.temporal.temporal.env.db }}
         {{ if .Values.multiwovenConfig.skipDbMigration }}
         - name: SKIP_DB_CREATE
           value: "true"
@@ -76,8 +78,6 @@ spec:
           value: "true"
         {{ end }}
         {{ if not .Values.multipleDbHosts.enabled }}
-        - name: DB
-          value: {{ quote .Values.temporal.temporal.env.db }}
         - name: DB_PORT
           valueFrom:
             configMapKeyRef:
@@ -128,6 +128,8 @@ spec:
           value: {{ quote .Values.kubernetesClusterDomain }}
         {{ end }}
         {{ if .Values.multipleDbHosts.enabled }}
+        - name: TEMPORAL_DB_PLUGIN
+          value: {{ .Values.temporal.temporal.env.db | quote }}
         - name: TEMPORAL_DEFAULT_DB_NAME
           value: {{ .Values.multipleDbHosts.temporalDbName }}
         - name: TEMPORAL_DEFAULT_CONNECT_ADDR


### PR DESCRIPTION
… from values.yaml file

In certain customer environments, the presence of values (in values.yaml) that contain words like "password" are prohibited and can either block deployments or trigger additional (and blocking) security reviews with each PR. I have wrapped temporalPostgresPassword in an if-statement when secrets.enabled is set to true so these values can be safely removed from the values.yaml file in these cases. 