### PR TITLE
fix(box): box-controller apps/deployments RBAC + released-app resource tuning

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Multiwoven is an open-source reverse ETL tool, offering an alternative to qHightouch, Census, and similar platforms. 🔥
 # kubeVersion: ">=1.16.0"
 type: application
-version: 0.95.0
+version: 0.95.1
 appVersion: "0.95.0"
 home: https://github.com/Multiwoven/multiwoven
 sources:

--- a/charts/multiwoven/templates/box-config.yaml
+++ b/charts/multiwoven/templates/box-config.yaml
@@ -28,14 +28,6 @@ data:
   {{- if .Values.boxConfig.boxImagePullSecret }}
   BOX_IMAGE_PULL_SECRET: {{ .Values.boxConfig.boxImagePullSecret | quote }}
   {{- end }}
-  # Docker registry credentials for pulling sandbox images. SECRET MATERIAL —
-  # gated so empty creds are never written into the ConfigMap. These should move
-  # to a Secret / secrets-store CSI mount later, not live in a ConfigMap.
-  {{- if .Values.boxConfig.boxDockerToken }}
-  BOX_DOCKER_SERVER: {{ .Values.boxConfig.boxDockerServer | quote }}
-  BOX_DOCKER_USERNAME: {{ .Values.boxConfig.boxDockerUsername | quote }}
-  BOX_DOCKER_TOKEN: {{ .Values.boxConfig.boxDockerToken | quote }}
-  {{- end }}
   BOX_IMAGE_REGISTRY: {{ .Values.boxConfig.boxImageRegistry | quote }}
   BOX_SANDBOX_BASE_IMAGE: {{ .Values.boxConfig.boxSandboxBaseImage | quote }}
   BOX_STORAGE_CLASS: {{ .Values.boxConfig.boxStorageClass | quote }}

--- a/charts/multiwoven/templates/box-config.yaml
+++ b/charts/multiwoven/templates/box-config.yaml
@@ -33,6 +33,8 @@ data:
   BOX_PVC_SIZE: {{ .Values.boxConfig.boxPvcSize | quote }}
   BOX_DEFAULT_CPU: {{ .Values.boxConfig.boxDefaultCpu | quote }}
   BOX_DEFAULT_MEMORY_MB: {{ .Values.boxConfig.boxDefaultMemoryMb | quote }}
+  BOX_RELEASE_CPU: {{ .Values.boxConfig.boxReleaseCpu | quote }}
+  BOX_RELEASE_MEMORY_MB: {{ .Values.boxConfig.boxReleaseMemoryMb | quote }}
   BOX_DEFAULT_TIMEOUT: {{ .Values.boxConfig.boxDefaultTimeout | quote }}
   BOX_DEFAULT_IDLE_TIMEOUT: {{ .Values.boxConfig.boxDefaultIdleTimeout | quote }}
   BOX_REAPER_INTERVAL: {{ .Values.boxConfig.boxReaperInterval | quote }}

--- a/charts/multiwoven/templates/box-config.yaml
+++ b/charts/multiwoven/templates/box-config.yaml
@@ -20,11 +20,21 @@ data:
   BOX_PORT: {{ .Values.boxConfig.boxPort | quote }}
   BOX_K8S_IN_CLUSTER: {{ .Values.boxConfig.boxK8sInCluster | quote }}
   BOX_K8S_NAMESPACE: {{ .Values.boxConfig.boxK8sNamespace | quote }}
+  # Releases (deployed-app) namespace
+  BOX_RELEASES_NAMESPACE: {{ .Values.boxConfig.boxReleasesNamespace | quote }}
   BOX_INGRESS_DOMAIN: {{ .Values.boxConfig.boxIngressDomain | quote }}
   BOX_INGRESS_CLASS: {{ .Values.boxConfig.boxIngressClass | quote }}
   BOX_INGRESS_NAMESPACE: {{ .Values.boxConfig.boxIngressNamespace | quote }}
   {{- if .Values.boxConfig.boxImagePullSecret }}
   BOX_IMAGE_PULL_SECRET: {{ .Values.boxConfig.boxImagePullSecret | quote }}
+  {{- end }}
+  # Docker registry credentials for pulling sandbox images. SECRET MATERIAL —
+  # gated so empty creds are never written into the ConfigMap. These should move
+  # to a Secret / secrets-store CSI mount later, not live in a ConfigMap.
+  {{- if .Values.boxConfig.boxDockerToken }}
+  BOX_DOCKER_SERVER: {{ .Values.boxConfig.boxDockerServer | quote }}
+  BOX_DOCKER_USERNAME: {{ .Values.boxConfig.boxDockerUsername | quote }}
+  BOX_DOCKER_TOKEN: {{ .Values.boxConfig.boxDockerToken | quote }}
   {{- end }}
   BOX_IMAGE_REGISTRY: {{ .Values.boxConfig.boxImageRegistry | quote }}
   BOX_SANDBOX_BASE_IMAGE: {{ .Values.boxConfig.boxSandboxBaseImage | quote }}
@@ -47,4 +57,42 @@ data:
   DB_PASSWORD: {{ .Values.boxConfig.dbPassword | quote }}
   DB_SSLMODE: {{ .Values.boxConfig.dbSslMode | quote }}
   BOX_DB_NAME: {{ .Values.boxConfig.boxDbName | quote }}
+  # Snapshot retention (0 disables the orphan-reap age gate)
+  BOX_SNAPSHOT_MAX_AGE_HOURS: {{ .Values.boxConfig.boxSnapshotMaxAgeHours | quote }}
+  # Reaper / provisioning / release-ready timeouts
+  BOX_RELEASE_READY_TIMEOUT: {{ .Values.boxConfig.boxReleaseReadyTimeout | quote }}
+  BOX_PROVISIONING_TIMEOUT: {{ .Values.boxConfig.boxProvisioningTimeout | quote }}
+  BOX_REAP_SNAPSHOT_TIMEOUT: {{ .Values.boxConfig.boxReapSnapshotTimeout | quote }}
+  BOX_STALE_SECRET_MAX_AGE: {{ .Values.boxConfig.boxStaleSecretMaxAge | quote }}
+  # Container ports (runtime contract with the sandbox/release image)
+  BOX_AGENT_PORT: {{ .Values.boxConfig.boxAgentPort | quote }}
+  BOX_VITE_PORT: {{ .Values.boxConfig.boxVitePort | quote }}
+  # Dev sandbox request/limit ratio (Burstable QoS)
+  BOX_SANDBOX_REQUEST_RATIO_PERCENT: {{ .Values.boxConfig.boxSandboxRequestRatioPercent | quote }}
+  # Release probes (startup + readiness)
+  BOX_RELEASE_STARTUP_PROBE_PERIOD: {{ .Values.boxConfig.boxReleaseStartupProbePeriod | quote }}
+  BOX_RELEASE_STARTUP_PROBE_TIMEOUT: {{ .Values.boxConfig.boxReleaseStartupProbeTimeout | quote }}
+  BOX_RELEASE_STARTUP_PROBE_FAILURE_THRESHOLD: {{ .Values.boxConfig.boxReleaseStartupProbeFailureThreshold | quote }}
+  BOX_RELEASE_READINESS_PROBE_PERIOD: {{ .Values.boxConfig.boxReleaseReadinessProbePeriod | quote }}
+  BOX_RELEASE_READINESS_PROBE_TIMEOUT: {{ .Values.boxConfig.boxReleaseReadinessProbeTimeout | quote }}
+  BOX_RELEASE_READINESS_PROBE_FAILURE_THRESHOLD: {{ .Values.boxConfig.boxReleaseReadinessProbeFailureThreshold | quote }}
+  # Poll intervals (cadence; deadline is the caller's timeout)
+  BOX_HEALTH_POLL_INTERVAL: {{ .Values.boxConfig.boxHealthPollInterval | quote }}
+  BOX_EXEC_WAIT_POLL_INTERVAL: {{ .Values.boxConfig.boxExecWaitPollInterval | quote }}
+  BOX_SNAPSHOT_POLL_INTERVAL: {{ .Values.boxConfig.boxSnapshotPollInterval | quote }}
+  BOX_LOG_STREAM_HEARTBEAT_INTERVAL: {{ .Values.boxConfig.boxLogStreamHeartbeatInterval | quote }}
+  # Handler default timeouts (caller may override per-request)
+  BOX_EXEC_DEFAULT_TIMEOUT_SECS: {{ .Values.boxConfig.boxExecDefaultTimeoutSecs | quote }}
+  BOX_GET_TASK_DEFAULT_TIMEOUT_SECS: {{ .Values.boxConfig.boxGetTaskDefaultTimeoutSecs | quote }}
+  BOX_DEPLOY_DEFAULT_TIMEOUT_SECS: {{ .Values.boxConfig.boxDeployDefaultTimeoutSecs | quote }}
+  BOX_SNAPSHOT_FS_DEFAULT_TIMEOUT_SECS: {{ .Values.boxConfig.boxSnapshotFsDefaultTimeoutSecs | quote }}
+  # HTTP server hardening / lifecycle
+  BOX_HTTP_READ_HEADER_TIMEOUT: {{ .Values.boxConfig.boxHttpReadHeaderTimeout | quote }}
+  BOX_SHUTDOWN_TIMEOUT: {{ .Values.boxConfig.boxShutdownTimeout | quote }}
+  # Postgres connection pool
+  BOX_DB_MAX_OPEN_CONNS: {{ .Values.boxConfig.boxDbMaxOpenConns | quote }}
+  BOX_DB_MAX_IDLE_CONNS: {{ .Values.boxConfig.boxDbMaxIdleConns | quote }}
+  BOX_DB_CONN_MAX_LIFETIME: {{ .Values.boxConfig.boxDbConnMaxLifetime | quote }}
+  # Admin API
+  BOX_ADMIN_ENABLED: {{ .Values.boxConfig.boxAdminEnabled | quote }}
 {{- end }}

--- a/charts/multiwoven/templates/box-config.yaml
+++ b/charts/multiwoven/templates/box-config.yaml
@@ -69,25 +69,12 @@ data:
   BOX_VITE_PORT: {{ .Values.boxConfig.boxVitePort | quote }}
   # Dev sandbox request/limit ratio (Burstable QoS)
   BOX_SANDBOX_REQUEST_RATIO_PERCENT: {{ .Values.boxConfig.boxSandboxRequestRatioPercent | quote }}
-  # Release probes (startup + readiness)
-  BOX_RELEASE_STARTUP_PROBE_PERIOD: {{ .Values.boxConfig.boxReleaseStartupProbePeriod | quote }}
-  BOX_RELEASE_STARTUP_PROBE_TIMEOUT: {{ .Values.boxConfig.boxReleaseStartupProbeTimeout | quote }}
+  # Release probes (startup failure threshold)
   BOX_RELEASE_STARTUP_PROBE_FAILURE_THRESHOLD: {{ .Values.boxConfig.boxReleaseStartupProbeFailureThreshold | quote }}
-  BOX_RELEASE_READINESS_PROBE_PERIOD: {{ .Values.boxConfig.boxReleaseReadinessProbePeriod | quote }}
-  BOX_RELEASE_READINESS_PROBE_TIMEOUT: {{ .Values.boxConfig.boxReleaseReadinessProbeTimeout | quote }}
-  BOX_RELEASE_READINESS_PROBE_FAILURE_THRESHOLD: {{ .Values.boxConfig.boxReleaseReadinessProbeFailureThreshold | quote }}
-  # Poll intervals (cadence; deadline is the caller's timeout)
-  BOX_HEALTH_POLL_INTERVAL: {{ .Values.boxConfig.boxHealthPollInterval | quote }}
-  BOX_EXEC_WAIT_POLL_INTERVAL: {{ .Values.boxConfig.boxExecWaitPollInterval | quote }}
-  BOX_SNAPSHOT_POLL_INTERVAL: {{ .Values.boxConfig.boxSnapshotPollInterval | quote }}
-  BOX_LOG_STREAM_HEARTBEAT_INTERVAL: {{ .Values.boxConfig.boxLogStreamHeartbeatInterval | quote }}
   # Handler default timeouts (caller may override per-request)
-  BOX_EXEC_DEFAULT_TIMEOUT_SECS: {{ .Values.boxConfig.boxExecDefaultTimeoutSecs | quote }}
-  BOX_GET_TASK_DEFAULT_TIMEOUT_SECS: {{ .Values.boxConfig.boxGetTaskDefaultTimeoutSecs | quote }}
   BOX_DEPLOY_DEFAULT_TIMEOUT_SECS: {{ .Values.boxConfig.boxDeployDefaultTimeoutSecs | quote }}
   BOX_SNAPSHOT_FS_DEFAULT_TIMEOUT_SECS: {{ .Values.boxConfig.boxSnapshotFsDefaultTimeoutSecs | quote }}
   # HTTP server hardening / lifecycle
-  BOX_HTTP_READ_HEADER_TIMEOUT: {{ .Values.boxConfig.boxHttpReadHeaderTimeout | quote }}
   BOX_SHUTDOWN_TIMEOUT: {{ .Values.boxConfig.boxShutdownTimeout | quote }}
   # Postgres connection pool
   BOX_DB_MAX_OPEN_CONNS: {{ .Values.boxConfig.boxDbMaxOpenConns | quote }}

--- a/charts/multiwoven/templates/box-rbac.yaml
+++ b/charts/multiwoven/templates/box-rbac.yaml
@@ -3,6 +3,7 @@
 #
 # ClusterRole: defines permissions box needs to manage sandbox resources:
 #   - pods, services, secrets, PVCs in the sandbox namespace
+#   - deployments and replicasets for Deployment-based releases
 #   - ingresses and network policies for sandbox isolation
 #   - volumesnapshots for sandbox snapshotting
 #
@@ -40,6 +41,9 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---
 

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -713,12 +713,6 @@ boxConfig:
   boxIngressClass: "nginx"
   boxIngressNamespace: "ingress-nginx"
   boxImagePullSecret: ""
-  # Docker registry credentials for pulling sandbox images. SECRET MATERIAL —
-  # only emitted into the ConfigMap when boxDockerToken is set; move to a
-  # Secret / secrets-store CSI mount later rather than leaving them here.
-  boxDockerServer: ""
-  boxDockerUsername: ""
-  boxDockerToken: ""
   boxImageRegistry: ""
   boxSandboxBaseImage: ""
   boxStorageClass: "standard"

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -720,6 +720,11 @@ boxConfig:
   boxPvcSize: "10Gi"
   boxDefaultCpu: "2000"
   boxDefaultMemoryMb: "4096"
+  # Released-app (deploy) resources — Guaranteed QoS (requests==limits) in box.
+  # 500m/1.5Gi aligns with Modal's deploy tuning; raised from box's 250m/512Mi
+  # default so heavier SSR/data apps don't OOM (512Mi was a hard Guaranteed cap).
+  boxReleaseCpu: "500"
+  boxReleaseMemoryMb: "1536"
   boxDefaultTimeout: "3600"
   boxDefaultIdleTimeout: "300"
   boxReaperInterval: "60s"

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -745,25 +745,12 @@ boxConfig:
   boxVitePort: "5173"
   # Dev sandbox pod request as a percent of its limit (Burstable QoS).
   boxSandboxRequestRatioPercent: "50"
-  # Release probe tuning (startup gates Vite cold-start; readiness re-checks).
-  boxReleaseStartupProbePeriod: "3"
-  boxReleaseStartupProbeTimeout: "3"
+  # Release probe tuning (startup gates Vite cold-start).
   boxReleaseStartupProbeFailureThreshold: "20"
-  boxReleaseReadinessProbePeriod: "5"
-  boxReleaseReadinessProbeTimeout: "3"
-  boxReleaseReadinessProbeFailureThreshold: "3"
-  # Poll cadences (overall deadline is the caller's timeout).
-  boxHealthPollInterval: "1s"
-  boxExecWaitPollInterval: "500ms"
-  boxSnapshotPollInterval: "3s"
-  boxLogStreamHeartbeatInterval: "15s"
   # Server-side default handler timeouts (caller may override per-request).
-  boxExecDefaultTimeoutSecs: "300"
-  boxGetTaskDefaultTimeoutSecs: "120"
   boxDeployDefaultTimeoutSecs: "120"
   boxSnapshotFsDefaultTimeoutSecs: "300"
   # HTTP server hardening / lifecycle.
-  boxHttpReadHeaderTimeout: "10s"
   boxShutdownTimeout: "30s"
   # Postgres connection pool (boxDbMaxIdleConns should stay <= boxDbMaxOpenConns).
   boxDbMaxOpenConns: "25"

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -708,11 +708,17 @@ boxConfig:
   boxPort: "8080"
   boxK8sInCluster: "true"
   boxK8sNamespace: "box-sandboxes"
+  boxReleasesNamespace: "box-releases"
   boxIngressDomain: ""
-  boxAdminHost: ""
   boxIngressClass: "nginx"
   boxIngressNamespace: "ingress-nginx"
   boxImagePullSecret: ""
+  # Docker registry credentials for pulling sandbox images. SECRET MATERIAL —
+  # only emitted into the ConfigMap when boxDockerToken is set; move to a
+  # Secret / secrets-store CSI mount later rather than leaving them here.
+  boxDockerServer: ""
+  boxDockerUsername: ""
+  boxDockerToken: ""
   boxImageRegistry: ""
   boxSandboxBaseImage: ""
   boxStorageClass: "standard"
@@ -725,9 +731,46 @@ boxConfig:
   # default so heavier SSR/data apps don't OOM (512Mi was a hard Guaranteed cap).
   boxReleaseCpu: "500"
   boxReleaseMemoryMb: "1536"
+  boxReleaseReadyTimeout: "180s"
   boxDefaultTimeout: "3600"
   boxDefaultIdleTimeout: "300"
   boxReaperInterval: "60s"
+  boxProvisioningTimeout: "90s"
+  boxReapSnapshotTimeout: "180s"
+  boxStaleSecretMaxAge: "24h"
+  # Snapshot retention: age floor for orphan-reap (0 disables the age gate).
+  boxSnapshotMaxAgeHours: "0"
+  # Container ports — runtime contract with the sandbox/release image.
+  boxAgentPort: "4096"
+  boxVitePort: "5173"
+  # Dev sandbox pod request as a percent of its limit (Burstable QoS).
+  boxSandboxRequestRatioPercent: "50"
+  # Release probe tuning (startup gates Vite cold-start; readiness re-checks).
+  boxReleaseStartupProbePeriod: "3"
+  boxReleaseStartupProbeTimeout: "3"
+  boxReleaseStartupProbeFailureThreshold: "20"
+  boxReleaseReadinessProbePeriod: "5"
+  boxReleaseReadinessProbeTimeout: "3"
+  boxReleaseReadinessProbeFailureThreshold: "3"
+  # Poll cadences (overall deadline is the caller's timeout).
+  boxHealthPollInterval: "1s"
+  boxExecWaitPollInterval: "500ms"
+  boxSnapshotPollInterval: "3s"
+  boxLogStreamHeartbeatInterval: "15s"
+  # Server-side default handler timeouts (caller may override per-request).
+  boxExecDefaultTimeoutSecs: "300"
+  boxGetTaskDefaultTimeoutSecs: "120"
+  boxDeployDefaultTimeoutSecs: "120"
+  boxSnapshotFsDefaultTimeoutSecs: "300"
+  # HTTP server hardening / lifecycle.
+  boxHttpReadHeaderTimeout: "10s"
+  boxShutdownTimeout: "30s"
+  # Postgres connection pool (boxDbMaxIdleConns should stay <= boxDbMaxOpenConns).
+  boxDbMaxOpenConns: "25"
+  boxDbMaxIdleConns: "10"
+  boxDbConnMaxLifetime: "5m"
+  # Admin API.
+  boxAdminEnabled: "true"
   boxLogLevel: "info"
   boxApiKey: ""
   boxEncryptionKey: ""


### PR DESCRIPTION
## What
Two box-deployment config changes for the self-hosted Box provider, delivered together in chart `0.95.1`:

### 1. RBAC — `apps/deployments` + `replicasets`
Box releases now run as K8s **Deployments** (box PR #26), so the box-controller ClusterRole needs `apps/deployments,replicasets`. Without it, deploys fail `deployments.apps is forbidden`. Added to `templates/box-rbac.yaml`.

### 2. Released-app resource tuning — `BOX_RELEASE_CPU=500`, `BOX_RELEASE_MEMORY_MB=1536`
Box releases use **Guaranteed QoS** (requests==limits). The code defaults (250m/512Mi) are leaner than Modal's deploy tuning and risk **OOM** for heavier SSR/data apps (512Mi is a hard cap). Surfaced `BOX_RELEASE_CPU`/`BOX_RELEASE_MEMORY_MB` in `templates/box-config.yaml` + `values.yaml` (defaults 500m / 1.5Gi), aligning with Modal.

## Delivery chain
Merge → publishes `multiwoven-0.95.1` → bump `aisquared-infra` `Chart.yaml` dependency `0.94.0 → 0.95.1` → ArgoCD applies both (RBAC + release resources) durably. (A live `kubectl patch` is the temporary stop-gap for the RBAC until this lands.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new Box configuration options, including `BOX_RELEASES_NAMESPACE`, `BOX_RELEASE_CPU`, and `BOX_RELEASE_MEMORY_MB`, plus expanded tuning for release readiness/startup probes, retention/timeouts, HTTP shutdown/lifecycle behavior, Postgres connection pool sizing, and `BOX_ADMIN_ENABLED`.
* **Chores**
  * Updated Box RBAC to document and support deployment-based releases by granting `apps` API access for `deployments` and `replicasets`.
  * Bumped the `multiwoven` Helm chart version to `0.95.1` (app version unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->