### PR TITLE
Add appgen observability variable and lightning vars to support sagemaker endpoint

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -4,8 +4,8 @@ description: |
   Multiwoven is an open-source reverse ETL tool, offering an alternative to qHightouch, Census, and similar platforms. 🔥
 # kubeVersion: ">=1.16.0"
 type: application
-version: 0.95.1
-appVersion: "0.95.0"
+version: 0.96.0
+appVersion: "0.96.0"
 home: https://github.com/Multiwoven/multiwoven
 sources:
   - https://docs.squared.ai/open-source/guides/setup/helm

--- a/charts/multiwoven/templates/lightning-config.yaml
+++ b/charts/multiwoven/templates/lightning-config.yaml
@@ -54,7 +54,7 @@ data:
   XPERT_MODEL: {{ .Values.lightningConfig.xpertModel | quote }}
 
   INFERENCE_BACKEND: {{ .Values.lightningConfig.inferenceBackend | quote }}
-  AWS_REGION: {{ .Values.lightningConfig.awsRegion | quote }}
+  INFERENCE_AWS_REGION: {{ .Values.lightningConfig.inferenceAwsRegion | quote }}
 
   CHAT_SAGEMAKER_ENDPOINT: {{ .Values.lightningConfig.chatSagemakerEndpoint | quote }}
   EMBEDDING_SAGEMAKER_ENDPOINT: {{ .Values.lightningConfig.embeddingSagemakerEndpoint | quote }}

--- a/charts/multiwoven/templates/lightning-config.yaml
+++ b/charts/multiwoven/templates/lightning-config.yaml
@@ -52,4 +52,17 @@ data:
   XPERT_API_KEY: {{ .Values.lightningConfig.xpertApiKey | quote }}
   XPERT_ENDPOINT: {{ .Values.lightningConfig.xpertEndpoint | quote }}
   XPERT_MODEL: {{ .Values.lightningConfig.xpertModel | quote }}
+
+  INFERENCE_BACKEND: {{ .Values.lightningConfig.inferenceBackend | quote }}
+  AWS_REGION: {{ .Values.lightningConfig.awsRegion | quote }}
+
+  CHAT_SAGEMAKER_ENDPOINT: {{ .Values.lightningConfig.chatSagemakerEndpoint | quote }}
+  EMBEDDING_SAGEMAKER_ENDPOINT: {{ .Values.lightningConfig.embeddingSagemakerEndpoint | quote }}
+  JUDY_SAGEMAKER_ENDPOINT: {{ .Values.lightningConfig.judySagemakerEndpoint | quote }}
+  MULTIMODAL_CHAT_SAGEMAKER_ENDPOINT: {{ .Values.lightningConfig.multimodalChatSagemakerEndpoint | quote }}
+  PATHFINDER_SAGEMAKER_ENDPOINT: {{ .Values.lightningConfig.pathfinderSagemakerEndpoint | quote }}
+  POLY_SAGEMAKER_ENDPOINT: {{ .Values.lightningConfig.polySagemakerEndpoint | quote }}
+  SEEMORE_SAGEMAKER_ENDPOINT: {{ .Values.lightningConfig.seemoreSagemakerEndpoint | quote }}
+  SENTINEL_SAGEMAKER_ENDPOINT: {{ .Values.lightningConfig.sentinelSagemakerEndpoint | quote }}
+  STRUCTURED_EXTRACTION_SAGEMAKER_ENDPOINT: {{ .Values.lightningConfig.structuredExtractionSagemakerEndpoint | quote }}
 {{- end }}

--- a/charts/multiwoven/templates/multiwoven-config.yaml
+++ b/charts/multiwoven/templates/multiwoven-config.yaml
@@ -73,6 +73,7 @@ data:
   NEON_API_BASE_URL: {{ .Values.multiwovenConfig.neonApiBaseUrl | quote }}
   NEON_DEFAULT_REGION: {{ .Values.multiwovenConfig.neonDefaultRegion | quote }}
   NEW_RELIC_KEY: {{ .Values.multiwovenConfig.newRelicKey | quote }}
+  OPENCODE_OTLP_ENDPOINT: {{ .Values.sandboxConfig.opencodeOtlpEndpoint | quote }}
   OPENROUTER_API_KEY: {{ .Values.multiwovenConfig.openrouterApiKey | quote }}
   P2W_LLM_PROVIDER: {{ .Values.multiwovenConfig.p2wLlmProvider | quote }}
   P2W_LLM_API_KEY: {{ .Values.multiwovenConfig.p2wLlmApiKey | quote }}

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -146,6 +146,7 @@ sandboxConfig:
   codingAgentModelApiKey: ""
   modalTokenId: ""
   modalTokenSecret: ""
+  opencodeOtlpEndpoint: ""
   dockerHubRegistryUsername: ""
   dockerHubRegistryPassword: ""
 
@@ -196,6 +197,19 @@ lightningConfig:
   xpertApiKey: ""
   xpertEndpoint: ""
   xpertModel: ""
+
+  inferenceBackend: "huggingface"
+  awsRegion: ""
+
+  chatSagemakerEndpoint: ""
+  embeddingSagemakerEndpoint: ""
+  judySagemakerEndpoint: ""
+  multimodalChatSagemakerEndpoint: ""
+  pathfinderSagemakerEndpoint: ""
+  polySagemakerEndpoint: ""
+  seemoreSagemakerEndpoint: ""
+  sentinelSagemakerEndpoint: ""
+  structuredExtractionSagemakerEndpoint: ""
 
 
 automountServiceAccountToken:

--- a/charts/multiwoven/values.yaml
+++ b/charts/multiwoven/values.yaml
@@ -199,7 +199,7 @@ lightningConfig:
   xpertModel: ""
 
   inferenceBackend: "huggingface"
-  awsRegion: ""
+  inferenceAwsRegion: ""
 
   chatSagemakerEndpoint: ""
   embeddingSagemakerEndpoint: ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to **0.96.0**.

* **New Features**
  * Added inference backend configuration (including SageMaker endpoint support across multiple inference modes).
  * Added `OPENCODE_OTLP_ENDPOINT` to the runtime configuration for improved observability.
  * Extended Lightning deployment configuration with additional inference-related environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->