### PR TITLE
fix(box): grant box-controller update/patch on services for deploy cutover

### DIFF
--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Multiwoven is an open-source reverse ETL tool, offering an alternative to qHightouch, Census, and similar platforms. 🔥
 # kubeVersion: ">=1.16.0"
 type: application
-version: 0.95.1
+version: 0.96.0
 appVersion: "0.95.0"
 home: https://github.com/Multiwoven/multiwoven
 sources:

--- a/charts/multiwoven/Chart.yaml
+++ b/charts/multiwoven/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 # kubeVersion: ">=1.16.0"
 type: application
 version: 0.98.0
-appVersion: "0.97.0"
+appVersion: "0.98.0"
 home: https://github.com/Multiwoven/multiwoven
 sources:
   - https://docs.squared.ai/open-source/guides/setup/helm

--- a/charts/multiwoven/templates/box-rbac.yaml
+++ b/charts/multiwoven/templates/box-rbac.yaml
@@ -25,7 +25,10 @@ rules:
     verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["get", "list", "create", "delete"]
+    # update/patch are required for the deploy Service-selector cutover
+    # (SetServiceSelector); without them a redeploy can't switch traffic to the
+    # new release and the published app keeps serving the old version.
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "create", "delete"]


### PR DESCRIPTION
## Problem
The box-controller ClusterRole (`templates/box-rbac.yaml`) grants `services: [get, list, create, delete]`, but the deploy **Service-selector cutover** (`SetServiceSelector`) issues an UPDATE/PATCH on `box-deploy-svc-<app>`. Without `update`/`patch` it's **forbidden**, so on a **redeploy** the Service selector never moves to the new release-id → the published app keeps serving the **old** release (or 404s). The box logs this on every deploy:

```
ERROR deploy: failed to cut Service over to new release …
  cannot update resource "services" … in namespace "box-sandboxes" (forbidden)
```

(#137 added `update`/`patch` for `apps/deployments` but missed `services`.)

## Fix
Add `update`,`patch` to the `services` rule. Chart `0.95.1` → `0.95.2`.

## Verified live
Reproduced on self-hosted: first deploy serves (Service is *created* with the right selector), but the cutover UPDATE is denied — confirmed via the box deploy logs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded application permissions to allow updating and partially editing existing services during deployment traffic cutovers.
* **Chores**
  * Bumped the Helm chart version and app version from `0.97.0` to `0.98.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->